### PR TITLE
Prefer session input actions for composer writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Prefer the session slot's standard `inputActions` for composer writes, with scoped and legacy fallbacks for older hosts.
+
 ## [0.2.1] - 2026-08-27
 
 ### Fixed

--- a/src/client/TalkMicButton.tsx
+++ b/src/client/TalkMicButton.tsx
@@ -31,10 +31,22 @@ export interface TalkMicInjected {
   setDraft: (text: string) => void
   /** Send the transcription as a user message. */
   send: (text: string) => Promise<void>
+  /**
+   * Resolve the current master input facade for one session id through
+   * `sessions.scope(id)` + `conversation.input.for(actx)`; undefined when
+   * either service is unavailable (rc.8 builds without the scope exchange).
+   */
+  forSession?: (id: unknown) => { setDraft(text: string): void; submit(): void } | undefined
 }
 
 /** Full component props assembled by the input-slot renderer. */
 export type TalkMicProps = PropsRuntime<'conversation.input.left'> & InjectFace<TalkMicInjected>
+
+/** Structural face of the standard-kit input actions current master feeds every session-scope slot component. */
+interface RuntimeInputActions {
+  setDraft(text: string): void
+  submit(): void
+}
 
 /** Minimal structural face of the Web Speech API (Chrome/Edge). */
 interface SpeechRecognitionLike {
@@ -85,7 +97,36 @@ function supportedMime(): string | undefined {
  * @returns the button element.
  */
 export function TalkMicButton(props: TalkMicProps): ReactNode {
-  const { status, interrupt, transcribe, audio, setDraft, send, useProjection } = props
+  const { status, interrupt, transcribe, audio, setDraft, send, useProjection, forSession } = props
+  const inputActions = (props as Partial<Record<'inputActions', RuntimeInputActions>>).inputActions
+  const sessionIdProp = (props as Partial<Record<'sessionId', unknown>>).sessionId
+  const writeDraft = (text: string): void => {
+    if (inputActions !== undefined) {
+      inputActions.setDraft(text)
+      return
+    }
+    const facade = sessionIdProp !== undefined ? forSession?.(sessionIdProp) : undefined
+    if (facade !== undefined) {
+      facade.setDraft(text)
+      return
+    }
+    console.warn('[dsh-talk] falling back to rc.8 injected setDraft')
+    setDraft(text)
+  }
+  const submitText = async (text: string): Promise<void> => {
+    if (inputActions !== undefined) {
+      inputActions.setDraft(text)
+      inputActions.submit()
+      return
+    }
+    const facade = sessionIdProp !== undefined ? forSession?.(sessionIdProp) : undefined
+    if (facade !== undefined) {
+      facade.setDraft(text)
+      facade.submit()
+      return
+    }
+    await send(text)
+  }
   const [mic, setMic] = useState<MicViewModel>(initMic)
   const [recording, setRecording] = useState(false)
   const [settings, setSettings] = useState<TalkStatus | undefined>(undefined)
@@ -119,9 +160,9 @@ export function TalkMicButton(props: TalkMicProps): ReactNode {
     setMic(foldMic(micRef.current, trimmed === '' ? { kind: 'failed', message: 'empty transcription' } : { kind: 'transcribed', text: trimmed }))
     if (trimmed === '') return
     if (settingsRef.current?.record.autoSubmit === true) {
-      void send(trimmed)
+      void submitText(trimmed)
     } else {
-      setDraft(trimmed)
+      writeDraft(trimmed)
     }
   }
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -85,6 +85,17 @@ export async function apply(ctx: ClientContext): Promise<void> {
     const audio: TalkMicInjected['audio'] = async (utteranceId) =>
       unwrap<TalkAudio | null>(await talk.audio(utteranceId), 'audio')
     const conversation = scope.get('conversation') as IConversation | undefined
+    // Master's sanctioned id → session-scope-ctx exchange (same pattern
+    // ui-commands uses); resolves to undefined when either service is
+    // unavailable (rc.8 builds without the scope exchange).
+    const sessions = scope.get('sessions') as { scope?: (id: unknown) => unknown } | undefined
+    const forSession: NonNullable<TalkMicInjected['forSession']> = (id) => {
+      if (typeof id !== 'string') return undefined
+      if (conversation === undefined || sessions?.scope === undefined) return undefined
+      const actx = sessions.scope(id)
+      if (actx === undefined || actx === null) return undefined
+      return conversation.input.for(actx as Parameters<typeof conversation.input.for>[0])
+    }
     const setDraft: TalkMicInjected['setDraft'] = (text) => {
       conversation?.input.for(scope).setDraft(text)
     }
@@ -100,7 +111,7 @@ export async function apply(ctx: ClientContext): Promise<void> {
       name: 'conversation.input.left',
       id: 'talk-mic',
       order: 20,
-      inject: (): TalkMicInjected => ({ status, interrupt, transcribe, audio, setDraft, send }),
+      inject: (): TalkMicInjected => ({ status, interrupt, transcribe, audio, setDraft, send, forSession }),
     }, TalkMicButton))
 
     scope.slots.inject('settings.plugins.tab', () => scope.slots.register({


### PR DESCRIPTION
Part 1 of the items 1 to 4 stack. Merge first.

Problem: setDraft/submit resolved through conversation.input.for(actx) crash on current DSH (input.for now requires a session scope); on rc.8 the same call worked, so the plugin broke only after the harness upgrade.

Fix: resolve writes through the session standard kit first (props.inputActions, promised on every conversation.input.left component), fall back to sessions.scope(id) plus facade for older hosts, and keep the injected setDraft as a last resort (warned). Same ladder in writeDraft and submitText.

Files: src/client/TalkMicButton.tsx, src/client/index.ts.
Tests: existing composer-write coverage through scripted kit props.