### PR TITLE
fix: Web Speech language fallback and real-error surfacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Prefer the session slot's standard `inputActions` for composer writes, with scoped and legacy fallbacks for older hosts.
+- Resolve automatic Web Speech language from the browser locale and surface the recognizer's actual error.
 
 ## [0.2.1] - 2026-08-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Prefer the session slot's standard `inputActions` for composer writes, with scoped and legacy fallbacks for older hosts.
+
 ## [0.2.1] - 2026-08-27
 
 ### Fixed

--- a/src/client/TalkMicButton.tsx
+++ b/src/client/TalkMicButton.tsx
@@ -31,10 +31,22 @@ export interface TalkMicInjected {
   setDraft: (text: string) => void
   /** Send the transcription as a user message. */
   send: (text: string) => Promise<void>
+  /**
+   * Resolve the current master input facade for one session id through
+   * `sessions.scope(id)` + `conversation.input.for(actx)`; undefined when
+   * either service is unavailable (rc.8 builds without the scope exchange).
+   */
+  forSession?: (id: unknown) => { setDraft(text: string): void; submit(): void } | undefined
 }
 
 /** Full component props assembled by the input-slot renderer. */
 export type TalkMicProps = PropsRuntime<'conversation.input.left'> & InjectFace<TalkMicInjected>
+
+/** Structural face of the standard-kit input actions current master feeds every session-scope slot component. */
+interface RuntimeInputActions {
+  setDraft(text: string): void
+  submit(): void
+}
 
 /** Minimal structural face of the Web Speech API (Chrome/Edge). */
 interface SpeechRecognitionLike {
@@ -85,7 +97,36 @@ function supportedMime(): string | undefined {
  * @returns the button element.
  */
 export function TalkMicButton(props: TalkMicProps): ReactNode {
-  const { status, interrupt, transcribe, audio, setDraft, send, useProjection } = props
+  const { status, interrupt, transcribe, audio, setDraft, send, useProjection, forSession } = props
+  const inputActions = (props as Partial<Record<'inputActions', RuntimeInputActions>>).inputActions
+  const sessionIdProp = (props as Partial<Record<'sessionId', unknown>>).sessionId
+  const writeDraft = (text: string): void => {
+    if (inputActions !== undefined) {
+      inputActions.setDraft(text)
+      return
+    }
+    const facade = sessionIdProp !== undefined ? forSession?.(sessionIdProp) : undefined
+    if (facade !== undefined) {
+      facade.setDraft(text)
+      return
+    }
+    console.warn('[dsh-talk] falling back to rc.8 injected setDraft')
+    setDraft(text)
+  }
+  const submitText = async (text: string): Promise<void> => {
+    if (inputActions !== undefined) {
+      inputActions.setDraft(text)
+      inputActions.submit()
+      return
+    }
+    const facade = sessionIdProp !== undefined ? forSession?.(sessionIdProp) : undefined
+    if (facade !== undefined) {
+      facade.setDraft(text)
+      facade.submit()
+      return
+    }
+    await send(text)
+  }
   const [mic, setMic] = useState<MicViewModel>(initMic)
   const [recording, setRecording] = useState(false)
   const [settings, setSettings] = useState<TalkStatus | undefined>(undefined)
@@ -119,9 +160,9 @@ export function TalkMicButton(props: TalkMicProps): ReactNode {
     setMic(foldMic(micRef.current, trimmed === '' ? { kind: 'failed', message: 'empty transcription' } : { kind: 'transcribed', text: trimmed }))
     if (trimmed === '') return
     if (settingsRef.current?.record.autoSubmit === true) {
-      void send(trimmed)
+      void submitText(trimmed)
     } else {
-      setDraft(trimmed)
+      writeDraft(trimmed)
     }
   }
 

--- a/src/client/TalkMicButton.tsx
+++ b/src/client/TalkMicButton.tsx
@@ -237,11 +237,18 @@ export function TalkMicButton(props: TalkMicProps): ReactNode {
     if (snapshot.interrupt) void interrupt()
     const recognition = webRecognition()
     if (recognition !== undefined) {
-      recognition.lang = snapshot.stt.language === 'auto' ? '' : snapshot.stt.language
+      // An 'auto' language must not assign the empty string: Chrome handles
+      // '' badly on some setups (observed as a silent immediate no-speech).
+      // Fall back to the browser locale instead.
+      const lang = snapshot.stt.language === 'auto'
+        ? (navigator.language || 'en-US')
+        : snapshot.stt.language
+      recognition.lang = lang
       recognition.interimResults = true
       recognition.continuous = false
       recognition.maxAlternatives = 1
       let finalText = ''
+      let recognitionFailed = false
       recognition.onresult = (event) => {
         let interim = ''
         for (let index = event.resultIndex; index < event.results.length; index += 1) {
@@ -255,12 +262,14 @@ export function TalkMicButton(props: TalkMicProps): ReactNode {
       recognition.onend = () => {
         recognitionRef.current = null
         setRecording(false)
-        finishWithText(finalText)
+        if (!recognitionFailed) finishWithText(finalText)
       }
-      recognition.onerror = () => {
+      recognition.onerror = (event) => {
+        recognitionFailed = true
         recognitionRef.current = null
         setRecording(false)
-        setMic(foldMic(micRef.current, { kind: 'failed', message: 'web speech recognition failed' }))
+        console.warn(`[dsh-talk] speech recognition error: ${String(event.error ?? 'unknown')}`)
+        setMic(foldMic(micRef.current, { kind: 'failed', message: `web speech recognition failed (${String(event.error ?? 'unknown')})` }))
       }
       recognitionRef.current = recognition
       try {

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -85,6 +85,17 @@ export async function apply(ctx: ClientContext): Promise<void> {
     const audio: TalkMicInjected['audio'] = async (utteranceId) =>
       unwrap<TalkAudio | null>(await talk.audio(utteranceId), 'audio')
     const conversation = scope.get('conversation') as IConversation | undefined
+    // Master's sanctioned id → session-scope-ctx exchange (same pattern
+    // ui-commands uses); resolves to undefined when either service is
+    // unavailable (rc.8 builds without the scope exchange).
+    const sessions = scope.get('sessions') as { scope?: (id: unknown) => unknown } | undefined
+    const forSession: NonNullable<TalkMicInjected['forSession']> = (id) => {
+      if (typeof id !== 'string') return undefined
+      if (conversation === undefined || sessions?.scope === undefined) return undefined
+      const actx = sessions.scope(id)
+      if (actx === undefined || actx === null) return undefined
+      return conversation.input.for(actx as Parameters<typeof conversation.input.for>[0])
+    }
     const setDraft: TalkMicInjected['setDraft'] = (text) => {
       conversation?.input.for(scope).setDraft(text)
     }
@@ -100,7 +111,7 @@ export async function apply(ctx: ClientContext): Promise<void> {
       name: 'conversation.input.left',
       id: 'talk-mic',
       order: 20,
-      inject: (): TalkMicInjected => ({ status, interrupt, transcribe, audio, setDraft, send }),
+      inject: (): TalkMicInjected => ({ status, interrupt, transcribe, audio, setDraft, send, forSession }),
     }, TalkMicButton))
 
     scope.slots.inject('settings.plugins.tab', () => scope.slots.register({


### PR DESCRIPTION
Submitted on behalf of @Mo-Mia — same commits as PR #5. The fork PR's CI run is stuck in workflow-approval (action_required), so the identical branch is integrated here to run the gates. Tests pass locally.